### PR TITLE
Fix warn on save

### DIFF
--- a/frontend/src/pages/recipebooks/edit/[recipeBook].tsx
+++ b/frontend/src/pages/recipebooks/edit/[recipeBook].tsx
@@ -45,6 +45,7 @@ const EditRecipeBook = ({
 
   /* Keep track of the different parts of the state */
   const [error, setError] = useState<string | undefined>(undefined);
+  const [submitted, setSubmitted] = useState(false);
   const [name, setName] = useState(recipeBook?.name ?? "");
   const [author, setAuthor] = useState(recipeBook?.author ?? "");
   const [image, setImage] = useState(recipeBook?.image ?? null);
@@ -62,7 +63,7 @@ const EditRecipeBook = ({
 
   useEffect(() => {
     const confirmLeaveFunc = function (e: BeforeUnloadEvent) {
-      if (unsavedChanges) {
+      if (unsavedChanges && !submitted) {
         e.preventDefault(); // If you prevent default behavior in Mozilla Firefox prompt will always be shown
         // Chrome requires returnValue to be set
         e.returnValue = "";
@@ -71,7 +72,7 @@ const EditRecipeBook = ({
 
     window.addEventListener("beforeunload", confirmLeaveFunc);
     return () => window.removeEventListener("beforeunload", confirmLeaveFunc);
-  }, [unsavedChanges]);
+  }, [unsavedChanges, submitted]);
 
   if (dataLoadError) {
     return <ErrorCard error={dataLoadError} />;
@@ -96,6 +97,7 @@ const EditRecipeBook = ({
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setSubmitted(true);
 
     let images: string[] = [];
     if (image) {
@@ -114,6 +116,7 @@ const EditRecipeBook = ({
       .then((response: ApiResponse<UniqueName>) => {
         if (response.error && response.errorTranslationString) {
           setError(translate(response.errorTranslationString));
+          setSubmitted(false);
         } else {
           window.location.assign(
             `${RECIPE_BOOKS_BASE_ENDPOINT}/${response.data?.uniqueName}`

--- a/frontend/src/pages/recipes/edit/[recipe].tsx
+++ b/frontend/src/pages/recipes/edit/[recipe].tsx
@@ -152,6 +152,7 @@ const EditRecipe = ({ recipe, dataLoadError, tags }: EditRecipeProps) => {
     Api.recipes.edit(newRecipe).then((response: ApiResponse<UniqueName>) => {
       if (response.error && response.errorTranslationString) {
         setError(translate(response.errorTranslationString));
+        setSubmitted(false);
       } else {
         window.location.assign(
           `${RECIPES_BASE_ENDPOINT}/${response.data?.uniqueName}`


### PR DESCRIPTION
Previously warn on save had been fixed so that it didn't warn when
pressing the save button, however, this had only been fixed for recipes
and not for recipebooks.

Furthermore, this fix had not considered API errors which meant that the
feature would not work after such an unsuccessful save.